### PR TITLE
Fix gemspec to work with pundit >= 1.0.0

### DIFF
--- a/policy-assertions.gemspec
+++ b/policy-assertions.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '~> 5.6'
   spec.add_development_dependency 'actionpack', '>= 3.0.0'
-  spec.add_development_dependency 'rack', '~>1.6.1'
+  spec.add_development_dependency 'rack', '~> 1.6.1'
   spec.add_development_dependency 'rack-test', '~> 0.6.3'
 
-  spec.add_dependency 'pundit', '~> 1.0.0'
+  spec.add_dependency 'pundit', '>= 1.0.0'
   spec.add_dependency 'activesupport', '>= 3.0.0'
 end


### PR DESCRIPTION
When adding the gem to the gemfile, I got a bundler error:

```
Bundler could not find compatible versions for gem "pundit":
  In snapshot (Gemfile.lock):
    pundit (= 1.1.0)

  In Gemfile:
    policy-assertions (>= 0) ruby depends on
      pundit (~> 1.0.0) ruby

    pundit (>= 0) ruby
```

So, I updated the gemspec to allow any pundit version >= 1.0.0

